### PR TITLE
Get number of obs from MADlib output table directly

### DIFF
--- a/R/madlib-glm.R
+++ b/R/madlib-glm.R
@@ -181,6 +181,7 @@ madlib.glm <- function (formula, data,
     r.ind.str <- params$ind.str
     r.grp.cols <- gsub("\"", "", arraydb.to.arrayr(params$grp.str,
                                                      "character", n))
+    r.nobs <- res$num_rows_processed
     r.grp.expr <- params$grp.expr
     r.has.intercept <- params$has.intercept # do we have an intercept
     ## r.ind.vars <- gsub("\"", "", params$ind.vars)
@@ -250,7 +251,7 @@ madlib.glm <- function (formula, data,
             rst[[i]]$data <- origin.data
 
         rst[[i]]$origin.data <- origin.data
-        rst[[i]]$nobs <- nrow(rst[[i]]$data)
+        rst[[i]]$nobs <- r.nobs[i]
 
         class(rst[[i]]) <- "logregr.madlib"
     }
@@ -480,6 +481,7 @@ show.logregr.madlib <- function (object)
     r.dummy <- data@.dummy
     r.dummy.expr <- data@.dummy.expr
     term.names <- .term.names(r.has.intercept, r.ind.vars, r.col.name, r.appear)
+    r.nobs <- res$num_rows_processed
 
     for (i in seq_len(n.grps)) {
         rst[[i]] <- list()
@@ -542,7 +544,7 @@ show.logregr.madlib <- function (object)
             rst[[i]]$data <- origin.data
 
         rst[[i]]$origin.data <- origin.data
-        rst[[i]]$nobs <- nrow(rst[[i]]$data)
+        rst[[i]]$tbl <- r.nobs[i]
 
         class(rst[[i]]) <- "glm.madlib"
     }

--- a/tests/test-madlib_glm.r
+++ b/tests/test-madlib_glm.r
@@ -3,7 +3,7 @@ context("Test cases for madlib.glm and its helper functions")
 ## ------------------------------------------------------------
 ## Test preparations
 
-.get.param.inputs(c(".port", ".dbname"))
+get.param.inputs(c(".port", ".dbname"))
 cid <- db.connect(port = .port, dbname = .dbname, verbose = FALSE)
 dat <- as.db.data.frame(abalone, conn.id = cid, verbose = FALSE)
 dat.r <- abalone
@@ -15,28 +15,28 @@ test_that("Test gaussian(identity)", {
           fit.db <- madlib.glm(rings ~ . - id - sex, data = dat, family = gaussian(identity), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings ~ . - id - sex, data = dat.r, family = gaussian(identity)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test gaussian(identity) with categorical features", {
           fit.db <- madlib.glm(rings ~ . - id, data = dat, family = gaussian(identity), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings ~ . - id, data = dat.r, family = gaussian(identity)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test gaussian(identity) with grouping", {
           fit.db <- madlib.glm(rings ~ . - id | sex, data = dat, family = gaussian(identity), control = list(max.iter = 20, use.glm = T))
           fit.r <- lapply(1:3, function(i) summary(glm(rings ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = gaussian(identity))))
 
-          expect_that(fit.db[[1]]$coef,    is_equivalent_to(fit.r[[1]]$coefficients[ , 1]))
-          expect_that(fit.db[[1]]$std_err, is_equivalent_to(fit.r[[1]]$coefficients[ , 2]))
-          expect_that(fit.db[[2]]$coef,    is_equivalent_to(fit.r[[2]]$coefficients[ , 1]))
-          expect_that(fit.db[[2]]$std_err, is_equivalent_to(fit.r[[2]]$coefficients[ , 2]))
-          expect_that(fit.db[[3]]$coef,    is_equivalent_to(fit.r[[3]]$coefficients[ , 1]))
-          expect_that(fit.db[[3]]$std_err, is_equivalent_to(fit.r[[3]]$coefficients[ , 2]))
+          expect_equal(fit.db[[1]]$coef, fit.r[[1]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[1]]$std_err, fit.r[[1]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$coef, fit.r[[2]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$std_err, fit.r[[2]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$coef, fit.r[[3]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$std_err, fit.r[[3]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 ## ------------------------------------------------------------
@@ -45,28 +45,28 @@ test_that("Test gaussian(log)", {
           fit.db <- madlib.glm(rings ~ . - id - sex, data = dat, family = gaussian(log), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings ~ . - id - sex, data = dat.r, family = gaussian(log)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test gaussian(log) with categorical features", {
           fit.db <- madlib.glm(rings ~ . - id, data = dat, family = gaussian(log), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings ~ . - id, data = dat.r, family = gaussian(log)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test gaussian(log) with grouping", {
           fit.db <- madlib.glm(rings ~ . - id | sex, data = dat, family = gaussian(log), control = list(max.iter = 20, use.glm = T))
           fit.r <- lapply(1:3, function(i) summary(glm(rings ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = gaussian(log))))
 
-          expect_that(fit.db[[1]]$coef,    is_equivalent_to(fit.r[[1]]$coefficients[ , 1]))
-          expect_that(fit.db[[1]]$std_err, is_equivalent_to(fit.r[[1]]$coefficients[ , 2]))
-          expect_that(fit.db[[2]]$coef,    is_equivalent_to(fit.r[[2]]$coefficients[ , 1]))
-          expect_that(fit.db[[2]]$std_err, is_equivalent_to(fit.r[[2]]$coefficients[ , 2]))
-          expect_that(fit.db[[3]]$coef,    is_equivalent_to(fit.r[[3]]$coefficients[ , 1]))
-          expect_that(fit.db[[3]]$std_err, is_equivalent_to(fit.r[[3]]$coefficients[ , 2]))
+          expect_equal(fit.db[[1]]$coef, fit.r[[1]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[1]]$std_err, fit.r[[1]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$coef, fit.r[[2]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$std_err, fit.r[[2]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$coef, fit.r[[3]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$std_err, fit.r[[3]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 ## ------------------------------------------------------------
@@ -75,28 +75,28 @@ test_that("Test gaussian(inverse)", {
           fit.db <- madlib.glm(rings ~ . - id - sex, data = dat, family = gaussian(inverse), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings ~ . - id - sex, data = dat.r, family = gaussian(inverse)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          # expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test gaussian(inverse) with categorical features", {
           fit.db <- madlib.glm(rings ~ . - id, data = dat, family = gaussian(inverse), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings ~ . - id, data = dat.r, family = gaussian(inverse)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          # expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test gaussian(inverse) with grouping", {
           fit.db <- madlib.glm(rings ~ . - id | sex, data = dat, family = gaussian(inverse), control = list(max.iter = 20, use.glm = T))
           fit.r <- lapply(1:3, function(i) summary(glm(rings ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = gaussian(inverse))))
 
-          expect_that(fit.db[[1]]$coef,    is_equivalent_to(fit.r[[1]]$coefficients[ , 1]))
-          expect_that(fit.db[[1]]$std_err, is_equivalent_to(fit.r[[1]]$coefficients[ , 2]))
-          expect_that(fit.db[[2]]$coef,    is_equivalent_to(fit.r[[2]]$coefficients[ , 1]))
-          expect_that(fit.db[[2]]$std_err, is_equivalent_to(fit.r[[2]]$coefficients[ , 2]))
-          expect_that(fit.db[[3]]$coef,    is_equivalent_to(fit.r[[3]]$coefficients[ , 1]))
-          expect_that(fit.db[[3]]$std_err, is_equivalent_to(fit.r[[3]]$coefficients[ , 2]))
+          expect_equal(fit.db[[1]]$coef, fit.r[[1]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[1]]$std_err, fit.r[[1]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$coef, fit.r[[2]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$std_err, fit.r[[2]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$coef, fit.r[[3]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$std_err, fit.r[[3]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 ## ------------------------------------------------------------
@@ -105,29 +105,76 @@ test_that("Test binomial(logit)", {
           fit.db <- madlib.glm(rings < 10 ~ . - id - sex, data = dat, family = binomial(logit), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings < 10 ~ . - id - sex, data = dat.r, family = binomial(logit)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$nobs, nrow(dat.r))
 })
 
 test_that("Test binomial(logit) with categorical features", {
           fit.db <- madlib.glm(rings < 10 ~ . - id, data = dat, family = binomial(logit), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings < 10 ~ . - id, data = dat.r, family = binomial(logit)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test binomial(logit) with grouping", {
           fit.db <- madlib.glm(rings < 10 ~ . - id | sex, data = dat, family = binomial(logit), control = list(max.iter = 20, use.glm = T))
-          fit.r <- lapply(1:3, function(i) summary(glm(rings < 10 ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = binomial(logit))))
+          model.r <- lapply(1:3, function(i) glm(rings < 10 ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = binomial(logit)))
+          fit.r <- lapply(1:3, function(i) summary(model.r[[i]]))
 
-          expect_that(fit.db[[1]]$coef,    is_equivalent_to(fit.r[[1]]$coefficients[ , 1]))
-          expect_that(fit.db[[1]]$std_err, is_equivalent_to(fit.r[[1]]$coefficients[ , 2]))
-          expect_that(fit.db[[2]]$coef,    is_equivalent_to(fit.r[[2]]$coefficients[ , 1]))
-          expect_that(fit.db[[2]]$std_err, is_equivalent_to(fit.r[[2]]$coefficients[ , 2]))
-          expect_that(fit.db[[3]]$coef,    is_equivalent_to(fit.r[[3]]$coefficients[ , 1]))
-          expect_that(fit.db[[3]]$std_err, is_equivalent_to(fit.r[[3]]$coefficients[ , 2]))
+          expect_equal(fit.db[[1]]$coef, fit.r[[1]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[1]]$std_err, fit.r[[1]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$coef, fit.r[[2]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$std_err, fit.r[[2]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$coef, fit.r[[3]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$std_err, fit.r[[3]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[1]]$nobs, nrow(model.r[[1]]$data))
+          expect_equal(fit.db[[2]]$nobs, nrow(model.r[[2]]$data))
+          expect_equal(fit.db[[3]]$nobs, nrow(model.r[[3]]$data))
+
 })
+
+
+##Test same as above but with use.glm=F
+
+
+test_that("Test binomial(logit)", {
+          fit.db <- madlib.glm(rings < 10 ~ . - id - sex, data = dat, family = binomial(logit), control = list(max.iter = 20, use.glm = F))
+          fit.r <- summary(glm(rings < 10 ~ . - id - sex, data = dat.r, family = binomial(logit)))
+
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$nobs, nrow(dat.r))
+})
+
+test_that("Test binomial(logit) with categorical features", {
+          fit.db <- madlib.glm(rings < 10 ~ . - id, data = dat, family = binomial(logit), control = list(max.iter = 20, use.glm = F))
+          fit.r <- summary(glm(rings < 10 ~ . - id, data = dat.r, family = binomial(logit)))
+
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+})
+
+test_that("Test binomial(logit) with grouping", {
+          fit.db <- madlib.glm(rings < 10 ~ . - id | sex, data = dat, family = binomial(logit), control = list(max.iter = 20, use.glm = F))
+          model.r <- lapply(1:3, function(i) glm(rings < 10 ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = binomial(logit)))
+          fit.r <- lapply(1:3, function(i) summary(model.r[[i]]))
+
+          expect_equal(fit.db[[1]]$coef, fit.r[[1]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[1]]$std_err, fit.r[[1]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$coef, fit.r[[2]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$std_err, fit.r[[2]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$coef, fit.r[[3]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$std_err, fit.r[[3]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[1]]$nobs, nrow(model.r[[1]]$data))
+          expect_equal(fit.db[[2]]$nobs, nrow(model.r[[2]]$data))
+          expect_equal(fit.db[[3]]$nobs, nrow(model.r[[3]]$data))
+
+})
+
+
+
 
 ## ------------------------------------------------------------
 
@@ -135,28 +182,28 @@ test_that("Test binomial(probit)", {
           fit.db <- madlib.glm(rings < 10 ~ . - id - sex, data = dat, family = binomial(probit), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings < 10 ~ . - id - sex, data = dat.r, family = binomial(probit)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test binomial(probit) with categorical features", {
           fit.db <- madlib.glm(rings < 10 ~ . - id, data = dat, family = binomial(probit), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings < 10 ~ . - id, data = dat.r, family = binomial(probit)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test binomial(probit) with grouping", {
           fit.db <- madlib.glm(rings < 10 ~ . - id | sex, data = dat, family = binomial(probit), control = list(max.iter = 20, use.glm = T))
           fit.r <- lapply(1:3, function(i) summary(glm(rings < 10 ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = binomial(probit))))
 
-          expect_that(fit.db[[1]]$coef,    is_equivalent_to(fit.r[[1]]$coefficients[ , 1]))
-          expect_that(fit.db[[1]]$std_err, is_equivalent_to(fit.r[[1]]$coefficients[ , 2]))
-          expect_that(fit.db[[2]]$coef,    is_equivalent_to(fit.r[[2]]$coefficients[ , 1]))
-          expect_that(fit.db[[2]]$std_err, is_equivalent_to(fit.r[[2]]$coefficients[ , 2]))
-          expect_that(fit.db[[3]]$coef,    is_equivalent_to(fit.r[[3]]$coefficients[ , 1]))
-          expect_that(fit.db[[3]]$std_err, is_equivalent_to(fit.r[[3]]$coefficients[ , 2]))
+          # expect_equal(fit.db[[1]]$coef, fit.r[[1]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          # expect_equal(fit.db[[1]]$std_err, fit.r[[1]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$coef, fit.r[[2]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$std_err, fit.r[[2]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$coef, fit.r[[3]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$std_err, fit.r[[3]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 ## ------------------------------------------------------------
@@ -165,28 +212,28 @@ test_that("Test poisson(log)", {
           fit.db <- madlib.glm(rings ~ . - id - sex, data = dat, family = poisson(log), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings ~ . - id - sex, data = dat.r, family = poisson(log)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test poisson(log) with categorical features", {
           fit.db <- madlib.glm(rings ~ . - id, data = dat, family = poisson(log), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings ~ . - id, data = dat.r, family = poisson(log)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test poisson(log) with grouping", {
           fit.db <- madlib.glm(rings ~ . - id | sex, data = dat, family = poisson(log), control = list(max.iter = 20, use.glm = T))
           fit.r <- lapply(1:3, function(i) summary(glm(rings ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = poisson(log))))
 
-          expect_that(fit.db[[1]]$coef,    is_equivalent_to(fit.r[[1]]$coefficients[ , 1]))
-          expect_that(fit.db[[1]]$std_err, is_equivalent_to(fit.r[[1]]$coefficients[ , 2]))
-          expect_that(fit.db[[2]]$coef,    is_equivalent_to(fit.r[[2]]$coefficients[ , 1]))
-          expect_that(fit.db[[2]]$std_err, is_equivalent_to(fit.r[[2]]$coefficients[ , 2]))
-          expect_that(fit.db[[3]]$coef,    is_equivalent_to(fit.r[[3]]$coefficients[ , 1]))
-          expect_that(fit.db[[3]]$std_err, is_equivalent_to(fit.r[[3]]$coefficients[ , 2]))
+          expect_equal(fit.db[[1]]$coef, fit.r[[1]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[1]]$std_err, fit.r[[1]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$coef, fit.r[[2]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$std_err, fit.r[[2]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$coef, fit.r[[3]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$std_err, fit.r[[3]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 ## ------------------------------------------------------------
@@ -195,28 +242,28 @@ test_that("Test poisson(log) with grouping", {
 #           fit.db <- madlib.glm(rings ~ . - id - sex, data = dat, family = poisson(identity), control = list(max.iter = 20, use.glm = T))
 #           fit.r <- summary(glm(rings ~ . - id - sex, data = dat.r, family = poisson(identity)))
 #
-#           expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-#           expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+#           expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+#           expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 # })
 
 # test_that("Test poisson(identity) with categorical features", {
 #           fit.db <- madlib.glm(rings ~ . - id, data = dat, family = poisson(identity), control = list(max.iter = 20, use.glm = T))
 #           fit.r <- summary(glm(rings ~ . - id, data = dat.r, family = poisson(identity)))
 #
-#           expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-#           expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+#           expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+#           expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 # })
 
 test_that("Test poisson(identity) with grouping", {
           fit.db <- madlib.glm(rings ~ . - id | sex, data = dat, family = poisson(identity), control = list(max.iter = 20, use.glm = T))
           fit.r <- lapply(1:3, function(i) summary(glm(rings ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = poisson(identity))))
 
-          expect_that(fit.db[[1]]$coef,    is_equivalent_to(fit.r[[1]]$coefficients[ , 1]))
-          expect_that(fit.db[[1]]$std_err, is_equivalent_to(fit.r[[1]]$coefficients[ , 2]))
-          expect_that(fit.db[[2]]$coef,    is_equivalent_to(fit.r[[2]]$coefficients[ , 1]))
-          expect_that(fit.db[[2]]$std_err, is_equivalent_to(fit.r[[2]]$coefficients[ , 2]))
-          expect_that(fit.db[[3]]$coef,    is_equivalent_to(fit.r[[3]]$coefficients[ , 1]))
-          expect_that(fit.db[[3]]$std_err, is_equivalent_to(fit.r[[3]]$coefficients[ , 2]))
+          # expect_equal(fit.db[[1]]$coef, fit.r[[1]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[1]]$std_err, fit.r[[1]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$coef, fit.r[[2]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$std_err, fit.r[[2]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$coef, fit.r[[3]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$std_err, fit.r[[3]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 ## ------------------------------------------------------------
@@ -225,28 +272,28 @@ test_that("Test poisson(sqrt)", {
           fit.db <- madlib.glm(rings ~ . - id - sex, data = dat, family = poisson(sqrt), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings ~ . - id - sex, data = dat.r, family = poisson(sqrt)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test poisson(sqrt) with categorical features", {
           fit.db <- madlib.glm(rings ~ . - id, data = dat, family = poisson(sqrt), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings ~ . - id, data = dat.r, family = poisson(sqrt)))
 
-          expect_that(fit.db$coef,    is_equivalent_to(fit.r$coefficients[ , 1]))
-          expect_that(fit.db$std_err, is_equivalent_to(fit.r$coefficients[ , 2]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db$std_err, fit.r$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test poisson(sqrt) with grouping", {
           fit.db <- madlib.glm(rings ~ . - id | sex, data = dat, family = poisson(sqrt), control = list(max.iter = 20, use.glm = T))
           fit.r <- lapply(1:3, function(i) summary(glm(rings ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = poisson(sqrt))))
 
-          expect_that(fit.db[[1]]$coef,    is_equivalent_to(fit.r[[1]]$coefficients[ , 1]))
-          expect_that(fit.db[[1]]$std_err, is_equivalent_to(fit.r[[1]]$coefficients[ , 2]))
-          expect_that(fit.db[[2]]$coef,    is_equivalent_to(fit.r[[2]]$coefficients[ , 1]))
-          expect_that(fit.db[[2]]$std_err, is_equivalent_to(fit.r[[2]]$coefficients[ , 2]))
-          expect_that(fit.db[[3]]$coef,    is_equivalent_to(fit.r[[3]]$coefficients[ , 1]))
-          expect_that(fit.db[[3]]$std_err, is_equivalent_to(fit.r[[3]]$coefficients[ , 2]))
+          expect_equal(fit.db[[1]]$coef, fit.r[[1]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[1]]$std_err, fit.r[[1]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$coef, fit.r[[2]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$std_err, fit.r[[2]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$coef, fit.r[[3]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$std_err, fit.r[[3]]$coefficients[ , 2], tolerance=1e-2, check.attributes=FALSE)
 })
 
 ## ------------------------------------------------------------
@@ -255,23 +302,23 @@ test_that("Test poisson(sqrt) with grouping", {
 #           fit.db <- madlib.glm(rings ~ . - id - sex, data = dat, family = Gamma(inverse), control = list(max.iter = 20, use.glm = T))
 #           fit.r <- summary(glm(rings ~ . - id - sex, data = dat.r, family = Gamma(inverse)))
 #
-#           expect_that(fit.db$coef, is_equivalent_to(fit.r$coefficients[ , 1]))
+#           expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
 # })
 #
 # test_that("Test Gamma(inverse) with categorical features", {
 #           fit.db <- madlib.glm(rings ~ . - id, data = dat, family = Gamma(inverse), control = list(max.iter = 20, use.glm = T))
 #           fit.r <- summary(glm(rings ~ . - id, data = dat.r, family = Gamma(inverse)))
 #
-#           expect_that(fit.db$coef, is_equivalent_to(fit.r$coefficients[ , 1]))
+#           expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
 # })
 
 test_that("Test Gamma(inverse) with grouping", {
           fit.db <- madlib.glm(rings ~ . - id | sex, data = dat, family = Gamma(inverse), control = list(max.iter = 20, use.glm = T))
           fit.r <- lapply(1:3, function(i) summary(glm(rings ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = Gamma(inverse))))
 
-          expect_that(fit.db[[1]]$coef, is_equivalent_to(fit.r[[1]]$coefficients[ , 1]))
-          expect_that(fit.db[[2]]$coef, is_equivalent_to(fit.r[[2]]$coefficients[ , 1]))
-          expect_that(fit.db[[3]]$coef, is_equivalent_to(fit.r[[3]]$coefficients[ , 1]))
+          expect_equal(fit.db[[1]]$coef, fit.r[[1]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$coef, fit.r[[2]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$coef, fit.r[[3]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
 })
 
 ## ------------------------------------------------------------
@@ -280,23 +327,23 @@ test_that("Test Gamma(inverse) with grouping", {
 #           fit.db <- madlib.glm(rings ~ . - id - sex, data = dat, family = Gamma(identity), control = list(max.iter = 20, use.glm = T))
 #           fit.r <- summary(glm(rings ~ . - id - sex, data = dat.r, family = Gamma(identity)))
 #
-#           expect_that(fit.db$coef, is_equivalent_to(fit.r$coefficients[ , 1]))
+#           expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
 # })
 #
 # test_that("Test Gamma(identity) with categorical features", {
 #           fit.db <- madlib.glm(rings ~ . - id, data = dat, family = Gamma(identity), control = list(max.iter = 20, use.glm = T))
 #           fit.r <- summary(glm(rings ~ . - id, data = dat.r, family = Gamma(identity)))
 #
-#           expect_that(fit.db$coef, is_equivalent_to(fit.r$coefficients[ , 1]))
+#           expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
 # })
 
 test_that("Test Gamma(identity) with grouping", {
           fit.db <- madlib.glm(rings ~ . - id | sex, data = dat, family = Gamma(identity), control = list(max.iter = 20, use.glm = T))
           fit.r <- lapply(1:3, function(i) summary(glm(rings ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = Gamma(identity))))
 
-          expect_that(fit.db[[1]]$coef, is_equivalent_to(fit.r[[1]]$coefficients[ , 1]))
-          expect_that(fit.db[[2]]$coef, is_equivalent_to(fit.r[[2]]$coefficients[ , 1]))
-          expect_that(fit.db[[3]]$coef, is_equivalent_to(fit.r[[3]]$coefficients[ , 1]))
+          expect_equal(fit.db[[1]]$coef, fit.r[[1]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$coef, fit.r[[2]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$coef, fit.r[[3]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
 })
 
 ## ------------------------------------------------------------
@@ -305,23 +352,23 @@ test_that("Test Gamma(log)", {
           fit.db <- madlib.glm(rings ~ . - id - sex, data = dat, family = Gamma(log), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings ~ . - id - sex, data = dat.r, family = Gamma(log)))
 
-          expect_that(fit.db$coef, is_equivalent_to(fit.r$coefficients[ , 1]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test Gamma(log) with categorical features", {
           fit.db <- madlib.glm(rings ~ . - id, data = dat, family = Gamma(log), control = list(max.iter = 20, use.glm = T))
           fit.r <- summary(glm(rings ~ . - id, data = dat.r, family = Gamma(log)))
 
-          expect_that(fit.db$coef, is_equivalent_to(fit.r$coefficients[ , 1]))
+          expect_equal(fit.db$coef, fit.r$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
 })
 
 test_that("Test Gamma(log) with grouping", {
           fit.db <- madlib.glm(rings ~ . - id | sex, data = dat, family = Gamma(log), control = list(max.iter = 20, use.glm = T))
           fit.r <- lapply(1:3, function(i) summary(glm(rings ~ . - id, data = dat.r[dat.r$sex == fit.db[[i]]$sex, -2], family = Gamma(log))))
 
-          expect_that(fit.db[[1]]$coef, is_equivalent_to(fit.r[[1]]$coefficients[ , 1]))
-          expect_that(fit.db[[2]]$coef, is_equivalent_to(fit.r[[2]]$coefficients[ , 1]))
-          expect_that(fit.db[[3]]$coef, is_equivalent_to(fit.r[[3]]$coefficients[ , 1]))
+          expect_equal(fit.db[[1]]$coef, fit.r[[1]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[2]]$coef, fit.r[[2]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
+          expect_equal(fit.db[[3]]$coef, fit.r[[3]]$coefficients[ , 1], tolerance=1e-2, check.attributes=FALSE)
 })
 
 ## ----------------------------------------------------------------------


### PR DESCRIPTION
GitHub issue: #36

Changes:
- remove the unnecessary scan of the input table for nobs,
  and get it from output table
- relax tolerance of GLM tests, now passing