### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@ PivotalR
 =======
 
 PivotalR is a package that enables users of R, the most popular open source statistical programming language
-and environment, to interact with [Greenplum Database](http://www.greenplum.org)
-as well as [Apache HAWQ (incubating)](http://hawq.incubator.apache.org/)
-and the [PostgreSQL](http://www.postgresql.org/) for big data
+and environment, to interact with [Greenplum Database](https://www.greenplum.org/)
+as well as [Apache HAWQ (incubating)](https://hawq.incubator.apache.org/)
+and the [PostgreSQL](https://www.postgresql.org/) for big data
 analytics. It does so by providing an interface to the operations on tables/views in the database. These
 operations are almost the same as those of data.frame. Minimal amount of data is transfered between R and
 the database. Thus the users of R do not need to learn SQL when they
 operate on the objects in the database. PivotalR also lets the user to run the functions of the open source
 machine
-learning package [Apache MADlib (incubating)](http://madlib.incubator.apache.org/) directly from R.
+learning package [Apache MADlib (incubating)](https://madlib.incubator.apache.org/) directly from R.
 
 1. An Introduction to PivotalR
 

--- a/man/abalone.Rd
+++ b/man/abalone.Rd
@@ -61,7 +61,7 @@ continuous values have been scaled for use with an ANN (by dividing by
 200).
 }
 \source{
-  [1] The original data is downloaded from \url{http://archive.ics.uci.edu/ml/datasets/Abalone}
+  [1] The original data is downloaded from \url{https://archive.ics.uci.edu/ml/datasets/Abalone}
 
   [2] Warwick J Nash, Tracy L Sellers, Simon R Talbot, Andrew J Cawthorn and Wes B Ford (1994)
 "The Population Biology of Abalone (_Haliotis_ species) in Tasmania. I. Blacklip Abalone (H. rubra) from the North Coast and Islands of Bass Strait",

--- a/man/as.db.data.frame-methods.Rd
+++ b/man/as.db.data.frame-methods.Rd
@@ -186,7 +186,7 @@ and it defaults to 0.
 }
 
 \references{
-  [1] Greenplum database, \url{http://www.greenplum.org}
+  [1] Greenplum database, \url{https://www.greenplum.org/}
 }
 
 \seealso{

--- a/man/generic.bagging.Rd
+++ b/man/generic.bagging.Rd
@@ -44,7 +44,7 @@ generic.bagging(train, data, nbags = 10, fraction = 1)
 }
 
 \references{
-  [1] Wiki: bagging \url{http://en.wikipedia.org/wiki/Bootstrap_aggregating}
+  [1] Wiki: bagging \url{https://en.wikipedia.org/wiki/Bootstrap_aggregating}
 }
 
 \author{

--- a/man/getTree.rf.madlib.Rd
+++ b/man/getTree.rf.madlib.Rd
@@ -28,7 +28,7 @@ getTree.rf.madlib(object, k=1, ...) }
   A data frame object similar to R's getTree result.
 }
 \references{
-[1] Documentation of random forest in MADlib 1.7, \url{http://doc.madlib.net/latest/}
+[1] Documentation of random forest in MADlib 1.7, \url{https://madlib.apache.org/docs/latest/}
 }
 \author{
   Author: Predictive Analytics Team at Pivotal Inc.

--- a/man/madlib.arima.Rd
+++ b/man/madlib.arima.Rd
@@ -199,7 +199,7 @@ method = "CSS", optim.method = "LM", optim.control = list(), ...)
 
 \references{
   [1] Rob J Hyndman and George Athanasopoulos: Forecasting: principles
-  and practice, http://otexts.com/fpp/
+  and practice, https://otexts.com/fpp/
 
   [2] Robert H. Shumway, David S. Stoffer: Time Series Analysis and Its
   Applications With R Examples, Third edition Springer Texts in

--- a/man/madlib.elnet.Rd
+++ b/man/madlib.elnet.Rd
@@ -229,7 +229,7 @@ All parameters have been explained above. The only one left is \code{verbose}.
 
 [2] Shai Shalev-Shwartz and Ambuj Tewari, Stochastic Methods for l1 Regularized Loss Minimization. Proceedings of the 26th International Conference on Machine Learning, Montreal, Canada, 2009.
 
-[3] Elastic net regularization. http://en.wikipedia.org/wiki/Elastic_net_regularization
+[3] Elastic net regularization. https://en.wikipedia.org/wiki/Elastic_net_regularization
 
 [4] Kevin P. Murphy, Machine Learning: A Probabilistic Perspective, The MIT Press, Chap 13.4, 2012.
 

--- a/man/madlib.glm.Rd
+++ b/man/madlib.glm.Rd
@@ -331,24 +331,24 @@ madlib.glm(formula, data, family = gaussian, na.action = NULL, control
 \references{
 
     [1] Documentation of linear regression in lastest MADlib,
-    \url{http://doc.madlib.net/latest/group__grp__linreg.html}
+    \url{https://madlib.apache.org/docs/latest/group__grp__linreg.html}
 
     [2] Documentation of logistic regression in latest MADlib,
-    \url{http://doc.madlib.net/latest/group__grp__logreg.html}
+    \url{https://madlib.apache.org/docs/latest/group__grp__logreg.html}
 
     [3] Wikipedia: Iteratively reweighted least squares,
-    \url{http://en.wikipedia.org/wiki/IRLS}
+    \url{https://en.wikipedia.org/wiki/IRLS}
 
     [4] Wikipedia: Conjugate gradient method,
-    \url{http://en.wikipedia.org/wiki/Conjugate_gradient_method}
+    \url{https://en.wikipedia.org/wiki/Conjugate_gradient_method}
 
     [5] Wikipedia: Stochastic gradient descent,
-    \url{http://en.wikipedia.org/wiki/Stochastic_gradient_descent}
+    \url{https://en.wikipedia.org/wiki/Stochastic_gradient_descent}
 
-    [6] Wikipedia: Odds ratio, \url{http://en.wikipedia.org/wiki/Odds_ratio}
+    [6] Wikipedia: Odds ratio, \url{https://en.wikipedia.org/wiki/Odds_ratio}
 
     [7] Documentation of generalized linear regression in latest MADlib,
-    \url{http://doc.madlib.net/latest/group__grp__glm.html}
+    \url{https://madlib.apache.org/docs/latest/group__grp__glm.html}
 
 }
 

--- a/man/madlib.kmeans.Rd
+++ b/man/madlib.kmeans.Rd
@@ -120,7 +120,7 @@ madlib.kmeans(
 \references{
 
 [1] Documentation of kmeans clustering in the latest MADlib release,
-    \url{http://madlib.incubator.apache.org/docs/latest/group__grp__kmeans.html}
+    \url{https://madlib.incubator.apache.org/docs/latest/group__grp__kmeans.html}
 }
 
 \seealso{

--- a/man/madlib.lda.Rd
+++ b/man/madlib.lda.Rd
@@ -90,7 +90,7 @@
 }
 \references{
   [1] Documentation of LDA in the latest MADlib release,
-    \url{http://madlib.incubator.apache.org/docs/latest/group__grp__lda.html}
+    \url{https://madlib.incubator.apache.org/docs/latest/group__grp__lda.html}
 }
 \seealso{
 

--- a/man/madlib.lm.Rd
+++ b/man/madlib.lm.Rd
@@ -211,9 +211,9 @@ madlib.lm(formula, data, na.action = NULL, hetero = FALSE, na.as.level = FALSE, 
 }
 \references{
   [1] Wikipedia: Breusch-Pagan test,
-  \url{http://en.wikipedia.org/wiki/Breusch-Pagan_test}
+  \url{https://en.wikipedia.org/wiki/Breusch-Pagan_test}
   [2] Documentation of linear regression in MADlib v0.6,
-  \url{http://doc.madlib.net/v0.6/group__grp__linreg.html}.
+  \url{https://madlib.apache.org/docs/v0.6/group__grp__linreg.html}.
 }
 \note{
   \code{|} is not part of standard R formula object, but many R packages

--- a/man/madlib.randomForest.Rd
+++ b/man/madlib.randomForest.Rd
@@ -78,7 +78,7 @@ na.as.level = FALSE, verbose = FALSE, ...) }
   rf.madlib.grp in the case of grouping.
 }
 \references{
-[1] Documentation of random forest in MADlib 1.7, \url{http://doc.madlib.net/latest/}
+[1] Documentation of random forest in MADlib 1.7, \url{https://madlib.apache.org/docs/latest/}
 }
 \author{
   Author: Predictive Analytics Team at Pivotal Inc.

--- a/man/madlib.rpart.Rd
+++ b/man/madlib.rpart.Rd
@@ -78,7 +78,7 @@ control, na.as.level = FALSE, verbose = FALSE, ...) }
   dt.madlib.grp in the case of grouping.
 }
 \references{
-[1] Documentation of decision tree in MADlib 1.6, \url{http://doc.madlib.net/latest/}
+[1] Documentation of decision tree in MADlib 1.6, \url{https://madlib.apache.org/docs/latest/}
 }
 \author{
   Author: Predictive Analytics Team at Pivotal Inc.

--- a/man/margins.Rd
+++ b/man/margins.Rd
@@ -111,7 +111,7 @@ Terms(term = NULL)
 }
 
 \references{
-[1] Stata 13 help for margins, \url{http://www.stata.com/help.cgi?margins}
+[1] Stata 13 help for margins, \url{https://www.stata.com/help.cgi?margins}
 }
 
 \author{

--- a/man/pivotalr.Rd
+++ b/man/pivotalr.Rd
@@ -34,7 +34,7 @@ pivotalr()
   [1] RStudio and Inc. (2013). shiny: Web Application Framework for R. R
   package version 0.6.0. \url{https://cran.r-project.org/package=shiny}
 
-  [2] shiny website, \url{http://www.rstudio.com/shiny/}
+  [2] shiny website, \url{https://www.rstudio.com/shiny/}
 }
 
 \keyword{GUI}

--- a/man/pkg-package.Rd
+++ b/man/pkg-package.Rd
@@ -102,9 +102,9 @@ database execution. These include
   Maintainer: Frank McQuillan, Pivotal Inc. \email{fmcquillan@pivotal.io}
 }
 \references{
-  [1] MADlib website, \url{http://madlib.incubator.apache.org}
+  [1] MADlib website, \url{https://madlib.incubator.apache.org}
 
-  [2] MADlib user docs, \url{http://madlib.incubator.apache.org/docs/latest/}
+  [2] MADlib user docs, \url{https://madlib.incubator.apache.org/docs/latest/}
 
   [3] MADlib Wiki page, \url{ https://cwiki.apache.org/confluence/display/MADLIB}
 

--- a/man/plot.dt.madlib.Rd
+++ b/man/plot.dt.madlib.Rd
@@ -49,7 +49,7 @@
   The coordinates of the nodes are returned as a list, with components x and y.
 }
 \references{
-[1] Documentation of decision tree in MADlib 1.6, \url{http://doc.madlib.net/latest/}
+[1] Documentation of decision tree in MADlib 1.6, \url{https://madlib.apache.org/docs/latest/}
 }
 
 \author{

--- a/man/predict.dt.madlib.Rd
+++ b/man/predict.dt.madlib.Rd
@@ -49,7 +49,7 @@
     for that class.
 }
 \references{
-[1] Documentation of decision tree in MADlib 1.6, \url{http://doc.madlib.net/latest/}
+[1] Documentation of decision tree in MADlib 1.6, \url{https://madlib.apache.org/docs/latest/}
 }
 \author{
   Author: Predictive Analytics Team at Pivotal Inc.

--- a/man/predict.rf.madlib.Rd
+++ b/man/predict.rf.madlib.Rd
@@ -49,7 +49,7 @@
     for that class.
 }
 \references{
-[1] Documentation of random forests in MADlib 1.7, \url{http://doc.madlib.net/latest/}
+[1] Documentation of random forests in MADlib 1.7, \url{https://madlib.apache.org/docs/latest/}
 }
 \author{
   Author: Predictive Analytics Team at Pivotal Inc.

--- a/man/print.dt.madlib.Rd
+++ b/man/print.dt.madlib.Rd
@@ -20,7 +20,7 @@
         \code{\link{madlib.rpart}} } \item{digits}{ The number of digits to
         print for numerical values. } \item{\dots}{ Arguments to be passed to
         or from other methods. } } \references{ [1] Documentation of decision
-    tree in MADlib 1.6, \url{http://doc.madlib.net/latest/} } \author{ Author:
+    tree in MADlib 1.6, \url{https://madlib.apache.org/docs/latest/} } \author{ Author:
     Predictive Analytics Team at Pivotal Inc.
 
   Maintainer: Frank McQuillan, Pivotal Inc. \email{fmcquillan@pivotal.io}

--- a/man/print.rf.madlib.Rd
+++ b/man/print.rf.madlib.Rd
@@ -24,7 +24,7 @@
     \item{\dots}{ Arguments to be passed to
         or from other methods. } } 
 \references{ [1] Documentation of random
-    forest in MADlib 1.7, \url{http://doc.madlib.net/latest/} } 
+    forest in MADlib 1.7, \url{https://madlib.apache.org/docs/latest/} } 
 \author{ Author:
     Predictive Analytics Team at Pivotal Inc.
 

--- a/man/text.dt.madlib.Rd
+++ b/man/text.dt.madlib.Rd
@@ -63,7 +63,7 @@
 }
 
 \references{
-[1] Documentation of decision tree in MADlib 1.6, \url{http://doc.madlib.net/latest/}
+[1] Documentation of decision tree in MADlib 1.6, \url{https://madlib.apache.org/docs/latest/}
 }
 
 \author{

--- a/vignettes/RJournal.sty
+++ b/vignettes/RJournal.sty
@@ -275,9 +275,9 @@
 {{\normalfont\fontseries{b}\selectfont #1}}%
 {#1}}
 \let\pkg=\strong
-\newcommand{\CRANpkg}[1]{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}%
+\newcommand{\CRANpkg}[1]{\href{https://CRAN.R-project.org/package=#1}{\pkg{#1}}}%
 \let\cpkg=\CRANpkg
-\newcommand{\ctv}[1]{\href{http://CRAN.R-project.org/view=#1}{\emph{#1}}}
+\newcommand{\ctv}[1]{\href{https://CRAN.R-project.org/view=#1}{\emph{#1}}}
 
 % Example environments ---------------------------------------------------------
 \RequirePackage{fancyvrb}

--- a/vignettes/qian.bib
+++ b/vignettes/qian.bib
@@ -5,7 +5,7 @@
   address = {Vienna, Austria},
   year = {2012},
   note = {{ISBN} 3-900051-07-0},
-  url = {http://www.R-project.org/},
+  url = {https://www.R-project.org/},
 }
 
 @article{ihaka:1996,
@@ -22,7 +22,7 @@
     author = {{RStudio Inc.}},
     year = 2013,
     note = {R package version 0.6.0},
-    url = {http://CRAN.R-project.org/package=shiny}
+    url = {https://CRAN.R-project.org/package=shiny}
   }
 
 @Manual{rpostgresql,
@@ -30,7 +30,7 @@
     author = {Joe Conway and Dirk Eddelbuettel and Tomoaki Nishiyama and Sameer Kumar Prayaga and Neil Tiffin},
     year = {2013},
     note = {R package version 0.4},
-    url = {http://CRAN.R-project.org/package=RPostgreSQL}
+    url = {https://CRAN.R-project.org/package=RPostgreSQL}
 }
 
 @Manual{rodbc,
@@ -38,7 +38,7 @@
     author = {Brian Ripley and from 1999 to Oct 2002 Michael Lapsley},
     year = {2013},
     note = {R package version 1.3-7},
-    url = {http://CRAN.R-project.org/package=RODBC},
+    url = {https://CRAN.R-project.org/package=RODBC},
 }
 
 @Manual{madlib,
@@ -46,7 +46,7 @@
   author = {{Pivotal Inc.}},
   year = {2013},
   note = {version 1.4},
-  url = {http://madlib.net}
+  url = {https://madlib.apache.org/}
 }
 
 @manual{gpdb,
@@ -54,7 +54,7 @@
     author = {{Pivotal Inc.}},
     year = {2013},
     note = {version 4.2.4},
-    url = {http://www.pivotal.io/products/pivotal-greenplum-database}
+    url = {https://www.pivotal.io/products/pivotal-greenplum-database}
 }
 
 @Manual{hawq,
@@ -62,7 +62,7 @@
   author = {{Pivotal Inc.}},
   year = {2013},
   note = {version 1.0},
-  url = {http://www.pivotal.io/pivotal-products/pivotal-data-fabric/pivotal-hd}
+  url = {https://www.pivotal.io/pivotal-products/pivotal-data-fabric/pivotal-hd}
 }
 
 @Manual{pivotalr,
@@ -70,7 +70,7 @@
   author = {{Pivotal Inc.}},
   year = {2013},
   note = {version 0.1.8},
-  url = {http://cran.r-project.org/web/packages/PivotalR/index.html}
+  url = {https://cran.r-project.org/web/packages/PivotalR/index.html}
 }
 
 @Manual{hdfs,
@@ -78,13 +78,13 @@
   author = {{The Apache Software Foundation}},
   year = 2013,
 note = {version 0.23},
-  url = {http://hadoop.apache.org/docs/stable/hdfs_user_guide.html}
+  url = {https://hadoop.apache.org/docs/stable/hdfs_user_guide.html}
 }
 
 @misc{hadoop,
   title = {Hadoop},
   organization = {{The Apache Software Foundation}},
-  url = {http://hadoop.apache.org/}
+  url = {https://hadoop.apache.org/}
 }
 
 @Manual{stats,
@@ -93,7 +93,7 @@ note = {version 0.23},
     organization = {R Foundation for Statistical Computing},
     address = {Vienna, Austria},
     year = {2013},
-    url = {http://www.R-project.org/},
+    url = {https://www.R-project.org/},
 }
 
 @Manual{dplyr,
@@ -135,7 +135,7 @@ title = {dplyr: a grammar of data manipulation},
     organization = {Teradata Corporation},
     note = {version 1.0.1},
     year = {2012},
-    url = {http://downloads.teradata.com/download/applications/teradata-r}
+    url = {https://downloads.teradata.com/download/applications/teradata-r}
 }
 
 \bibliography{qian}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://r-pkgs.had.co.nz/ (200) with 1 occurrences could not be migrated:  
   ([https](https://r-pkgs.had.co.nz/) result ConnectTimeoutException).
* http://r-pkgs.had.co.nz/tests.html (200) with 1 occurrences could not be migrated:  
   ([https](https://r-pkgs.had.co.nz/tests.html) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://madlib.net (301) with 1 occurrences migrated to:  
  https://madlib.apache.org/ ([https](https://madlib.net) result SSLHandshakeException).
* http://doc.madlib.net/latest/ (301) with 9 occurrences migrated to:  
  https://madlib.apache.org/docs/latest/ ([https](https://doc.madlib.net/latest/) result SSLHandshakeException).
* http://doc.madlib.net/latest/group__grp__glm.html (301) with 1 occurrences migrated to:  
  https://madlib.apache.org/docs/latest/group__grp__glm.html ([https](https://doc.madlib.net/latest/group__grp__glm.html) result SSLHandshakeException).
* http://doc.madlib.net/latest/group__grp__linreg.html (301) with 1 occurrences migrated to:  
  https://madlib.apache.org/docs/latest/group__grp__linreg.html ([https](https://doc.madlib.net/latest/group__grp__linreg.html) result SSLHandshakeException).
* http://doc.madlib.net/latest/group__grp__logreg.html (301) with 1 occurrences migrated to:  
  https://madlib.apache.org/docs/latest/group__grp__logreg.html ([https](https://doc.madlib.net/latest/group__grp__logreg.html) result SSLHandshakeException).
* http://doc.madlib.net/v0.6/group__grp__linreg.html (301) with 1 occurrences migrated to:  
  https://madlib.apache.org/docs/v0.6/group__grp__linreg.html ([https](https://doc.madlib.net/v0.6/group__grp__linreg.html) result SSLHandshakeException).
* http://www.greenplum.org (301) with 2 occurrences migrated to:  
  https://www.greenplum.org/ ([https](https://www.greenplum.org) result SSLHandshakeException).
* http://downloads.teradata.com/download/applications/teradata-r (403) with 1 occurrences migrated to:  
  https://downloads.teradata.com/download/applications/teradata-r ([https](https://downloads.teradata.com/download/applications/teradata-r) result 403).
* http://CRAN.R-project.org/package= (404) with 1 occurrences migrated to:  
  https://CRAN.R-project.org/package= ([https](https://CRAN.R-project.org/package=) result 404).
* http://CRAN.R-project.org/view= (404) with 1 occurrences migrated to:  
  https://CRAN.R-project.org/view= ([https](https://CRAN.R-project.org/view=) result 404).
* http://hadoop.apache.org/docs/stable/hdfs_user_guide.html (404) with 1 occurrences migrated to:  
  https://hadoop.apache.org/docs/stable/hdfs_user_guide.html ([https](https://hadoop.apache.org/docs/stable/hdfs_user_guide.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://archive.ics.uci.edu/ml/datasets/Abalone with 1 occurrences migrated to:  
  https://archive.ics.uci.edu/ml/datasets/Abalone ([https](https://archive.ics.uci.edu/ml/datasets/Abalone) result 200).
* http://cran.r-project.org/web/packages/PivotalR/index.html with 1 occurrences migrated to:  
  https://cran.r-project.org/web/packages/PivotalR/index.html ([https](https://cran.r-project.org/web/packages/PivotalR/index.html) result 200).
* http://en.wikipedia.org/wiki/Bootstrap_aggregating with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Bootstrap_aggregating ([https](https://en.wikipedia.org/wiki/Bootstrap_aggregating) result 200).
* http://en.wikipedia.org/wiki/Breusch-Pagan_test with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Breusch-Pagan_test ([https](https://en.wikipedia.org/wiki/Breusch-Pagan_test) result 200).
* http://en.wikipedia.org/wiki/Conjugate_gradient_method with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Conjugate_gradient_method ([https](https://en.wikipedia.org/wiki/Conjugate_gradient_method) result 200).
* http://en.wikipedia.org/wiki/Elastic_net_regularization with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Elastic_net_regularization ([https](https://en.wikipedia.org/wiki/Elastic_net_regularization) result 200).
* http://en.wikipedia.org/wiki/IRLS with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/IRLS ([https](https://en.wikipedia.org/wiki/IRLS) result 200).
* http://en.wikipedia.org/wiki/Odds_ratio with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Odds_ratio ([https](https://en.wikipedia.org/wiki/Odds_ratio) result 200).
* http://en.wikipedia.org/wiki/Stochastic_gradient_descent with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Stochastic_gradient_descent ([https](https://en.wikipedia.org/wiki/Stochastic_gradient_descent) result 200).
* http://hadoop.apache.org/ with 1 occurrences migrated to:  
  https://hadoop.apache.org/ ([https](https://hadoop.apache.org/) result 200).
* http://www.R-project.org/ with 2 occurrences migrated to:  
  https://www.R-project.org/ ([https](https://www.R-project.org/) result 200).
* http://www.postgresql.org/ with 1 occurrences migrated to:  
  https://www.postgresql.org/ ([https](https://www.postgresql.org/) result 200).
* http://www.stata.com/help.cgi?margins with 1 occurrences migrated to:  
  https://www.stata.com/help.cgi?margins ([https](https://www.stata.com/help.cgi?margins) result 200).
* http://otexts.com/fpp/ with 1 occurrences migrated to:  
  https://otexts.com/fpp/ ([https](https://otexts.com/fpp/) result 301).
* http://www.pivotal.io/pivotal-products/pivotal-data-fabric/pivotal-hd with 1 occurrences migrated to:  
  https://www.pivotal.io/pivotal-products/pivotal-data-fabric/pivotal-hd ([https](https://www.pivotal.io/pivotal-products/pivotal-data-fabric/pivotal-hd) result 301).
* http://www.pivotal.io/products/pivotal-greenplum-database with 1 occurrences migrated to:  
  https://www.pivotal.io/products/pivotal-greenplum-database ([https](https://www.pivotal.io/products/pivotal-greenplum-database) result 301).
* http://www.rstudio.com/shiny/ with 1 occurrences migrated to:  
  https://www.rstudio.com/shiny/ ([https](https://www.rstudio.com/shiny/) result 301).
* http://hawq.incubator.apache.org/ with 1 occurrences migrated to:  
  https://hawq.incubator.apache.org/ ([https](https://hawq.incubator.apache.org/) result 302).
* http://madlib.incubator.apache.org with 1 occurrences migrated to:  
  https://madlib.incubator.apache.org ([https](https://madlib.incubator.apache.org) result 302).
* http://madlib.incubator.apache.org/ with 1 occurrences migrated to:  
  https://madlib.incubator.apache.org/ ([https](https://madlib.incubator.apache.org/) result 302).
* http://madlib.incubator.apache.org/docs/latest/ with 1 occurrences migrated to:  
  https://madlib.incubator.apache.org/docs/latest/ ([https](https://madlib.incubator.apache.org/docs/latest/) result 302).
* http://madlib.incubator.apache.org/docs/latest/group__grp__kmeans.html with 1 occurrences migrated to:  
  https://madlib.incubator.apache.org/docs/latest/group__grp__kmeans.html ([https](https://madlib.incubator.apache.org/docs/latest/group__grp__kmeans.html) result 302).
* http://madlib.incubator.apache.org/docs/latest/group__grp__lda.html with 1 occurrences migrated to:  
  https://madlib.incubator.apache.org/docs/latest/group__grp__lda.html ([https](https://madlib.incubator.apache.org/docs/latest/group__grp__lda.html) result 302).
* http://CRAN.R-project.org/package=RODBC with 1 occurrences migrated to:  
  https://CRAN.R-project.org/package=RODBC ([https](https://CRAN.R-project.org/package=RODBC) result 303).
* http://CRAN.R-project.org/package=RPostgreSQL with 1 occurrences migrated to:  
  https://CRAN.R-project.org/package=RPostgreSQL ([https](https://CRAN.R-project.org/package=RPostgreSQL) result 303).
* http://CRAN.R-project.org/package=shiny with 1 occurrences migrated to:  
  https://CRAN.R-project.org/package=shiny ([https](https://CRAN.R-project.org/package=shiny) result 303).